### PR TITLE
Implement add_recordings and delete_recordings endpoints

### DIFF
--- a/webserver/views/api/v1/test/test_datasets.py
+++ b/webserver/views/api/v1/test/test_datasets.py
@@ -22,6 +22,14 @@ class APIDatasetViewsTestCase(ServerTestCase):
         self.test_user_mb_name = "tester"
         self.test_user_id = db.user.create(self.test_user_mb_name)
         self.test_user = db.user.get(self.test_user_id)
+        self.correct_dataset = {
+            "public": True,
+            "name": "Dataset name",
+            "description": "Dataset description",
+            "author": self.test_user_id,
+            "classes": [{"name": "abc", "description": "abc class", "recordings": []}]
+        }
+
 
 
     def test_create_dataset_forbidden(self):
@@ -126,3 +134,134 @@ class APIDatasetViewsTestCase(ServerTestCase):
             webserver.views.api.v1.datasets.get_check_dataset("6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0")
         get.assert_called_once_with("6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0")
 
+    @mock.patch("db.dataset.get")
+    def test_add_recordings_dataset_private(self, get):
+        # Can't add recordings to dataset that doesn't belong to requesting user
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        dataset = {"public": True, "author": self.test_user_id+1, "classes": [{"name": "abc", "recordings": []}]}
+        get.return_value = dataset
+        response = self.client.put("/api/v1/datasets/%s/recordings" % dataset_id, data=json.dumps({"class_name": "abc", "recordings": []}), content_type="application/json")
+        self.assertEqual(response.status_code, 401)
+
+    @mock.patch("db.dataset.get")
+    def test_add_recordings_missing_field(self, get):
+        # One of the required request fields is missing
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        get.return_value = self.correct_dataset.copy()
+        response = self.client.put("/api/v1/datasets/%s/recordings" % dataset_id, data=json.dumps({"recordings": []}), content_type="application/json")
+        self.assertIn("You have to provide", response.data)
+        self.assertEqual(response.status_code, 400)
+
+    @mock.patch("db.dataset.get")
+    def test_add_recordings_wrong_class(self, get):
+        # Class you're trying to add recordings to the class that doesn't exist
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        dataset = {"public": True, "author": self.test_user_id, "classes": [{"name": "abc", "recordings": []}]}
+        get.return_value = dataset
+        response = self.client.put("/api/v1/datasets/%s/recordings" % dataset_id, data=json.dumps({"class_name": "acdbc", "recordings": []}), content_type="application/json")
+        print(response.data)
+        self.assertIn("class doesn't exist", response.data)
+        self.assertEqual(response.status_code, 400)
+
+    @mock.patch("db.dataset.get")
+    def test_add_recordings_data_not_json(self, get):
+        # Request body is not JSON
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        dataset = {"public": True, "author": self.test_user_id, "classes": [{"name": "abc", "recordings": []}]}
+        get.return_value = dataset
+        response = self.client.put("/api/v1/datasets/%s/recordings" % dataset_id, content_type="application/text")
+        self.assertIn("must be submitted in JSON format", response.data)
+        self.assertEqual(response.status_code, 400)
+
+    @mock.patch("db.dataset.get")
+    @mock.patch("db.dataset.update")
+    def test_add_recordings_correct(self, update, get):
+        # Recording is correctly added to the dataset
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        dataset = self.correct_dataset.copy()
+        get.return_value = dataset
+
+        response = self.client.put("/api/v1/datasets/%s/recordings" % dataset_id, data=json.dumps({"class_name": "abc", "recordings": ["e5323dc1-28ef-4cae-95fb-c3c9bb4391b0"]}), content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(update.called)
+        dataset_call = update.call_args[0][1]
+        self.assertEqual(dataset_call["classes"][0]["recordings"], ["e5323dc1-28ef-4cae-95fb-c3c9bb4391b0"])
+
+    @mock.patch("db.dataset.get")
+    @mock.patch("db.dataset.update")
+    def test_add_recordings_no_dup(self, update, get):
+        # Recordings are not duplicated
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        dataset = self.correct_dataset.copy()
+        dataset["classes"][0]["recordings"] = ["0a1db558-5b7c-49a2-a499-28eaf1896709"]
+        get.return_value = dataset
+
+        response = self.client.put("/api/v1/datasets/%s/recordings" % dataset_id, data=json.dumps({"class_name": "abc", "recordings": ["0a1db558-5b7c-49a2-a499-28eaf1896709", "e5323dc1-28ef-4cae-95fb-c3c9bb4391b0"]}), content_type="application/json")
+        dataset_call = update.call_args[0][1]
+        self.assertEqual(sorted(dataset_call["classes"][0]["recordings"]), sorted(["0a1db558-5b7c-49a2-a499-28eaf1896709", "e5323dc1-28ef-4cae-95fb-c3c9bb4391b0"]))
+
+    @mock.patch("db.dataset.get")
+    def test_delete_recordings_dataset_private(self, get):
+        # Can't add recordings to dataset that doesn't belong to requesting user
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        dataset = {"public": True, "author": self.test_user_id+1, "classes": [{"name": "abc", "recordings": []}]}
+        get.return_value = dataset
+        response = self.client.delete("/api/v1/datasets/%s/recordings" % dataset_id, data=json.dumps({"class_name": "abc", "recordings": []}), content_type="application/json")
+        self.assertEqual(response.status_code, 401)
+
+    @mock.patch("db.dataset.get")
+    def test_delete_recordings_missing_field(self, get):
+        # One of the required request fields is missing
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        get.return_value = self.correct_dataset.copy()
+        response = self.client.delete("/api/v1/datasets/%s/recordings" % dataset_id, data=json.dumps({"recordings": []}), content_type="application/json")
+        self.assertIn("You have to provide", response.data)
+        self.assertEqual(response.status_code, 400)
+
+    @mock.patch("db.dataset.get")
+    def test_delete_recordings_wrong_class(self, get):
+        # Class you're trying to add recordings to the class that doesn't exist
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        dataset = {"public": True, "author": self.test_user_id, "classes": [{"name": "abc", "recordings": []}]}
+        get.return_value = dataset
+        response = self.client.delete("/api/v1/datasets/%s/recordings" % dataset_id, data=json.dumps({"class_name": "acdbc", "recordings": []}), content_type="application/json")
+        print(response.data)
+        self.assertIn("class doesn't exist", response.data)
+        self.assertEqual(response.status_code, 400)
+
+    @mock.patch("db.dataset.get")
+    def test_delete_recordings_data_not_json(self, get):
+        # Request body is not JSON
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        dataset = {"public": True, "author": self.test_user_id, "classes": [{"name": "abc", "recordings": []}]}
+        get.return_value = dataset
+        response = self.client.delete("/api/v1/datasets/%s/recordings" % dataset_id, content_type="application/text")
+        self.assertIn("must be submitted in JSON format", response.data)
+        self.assertEqual(response.status_code, 400)
+
+    @mock.patch("db.dataset.get")
+    @mock.patch("db.dataset.update")
+    def test_delete_recordings_correct(self, update, get):
+        # Recording is correctly removed from a dataset
+        dataset_id = "6b6b9205-f9c8-4674-92f5-2ae17bcb3cb0"
+        self.temporary_login(self.test_user_id)
+        dataset = self.correct_dataset.copy()
+        dataset = self.correct_dataset.copy()
+        dataset["classes"][0]["recordings"] = ["0a1db558-5b7c-49a2-a499-28eaf1896709", "e5323dc1-28ef-4cae-95fb-c3c9bb4391b0"]
+        get.return_value = dataset
+
+        response = self.client.delete("/api/v1/datasets/%s/recordings" % dataset_id, data=json.dumps({"class_name": "abc", "recordings": ["0a1db558-5b7c-49a2-a499-28eaf1896709"]}), content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(update.called)
+        dataset_call = update.call_args[0][1]
+        self.assertEqual(dataset_call["classes"][0]["recordings"], ["e5323dc1-28ef-4cae-95fb-c3c9bb4391b0"])


### PR DESCRIPTION
Two endpoints and the relevant tests are implemented by this commit. They both make use of an already existent `update` method from `db.dataset`.
I have taken a design decision to use this method for several reasons:
- The fact it already exists, but is not yet used anywhere, suggests that it was created in a preparation for the forth development.
- The method already exists and ensures the correct structure of dataset with it's helper validation method.
- There is neither `class` nor `recording` module in the db lib and the task requires using methods from db.datasets. I believe that `recording` or `class`-specific methods should go to their own libs rather than to `db.datasets`.

Implementing these libs properly would take much more than 4 hours, but in a long term would be a better solution. Why? Because we could avoid recreating all classes and recordings every time we want to only add or delete a couple of recordings, which would be much more efficient regarding DB. However, in the current state of API, this doesn't seem to be a problem, as there are no endpoints for requesting single class or and classes belong exclusively to single dataset resource, so recreating them doesn't cause any internal app problems.

Also a `DELETE 'dataset'` endpoint was fixed and it works now.